### PR TITLE
GraphScreen.css: Make pie responsive

### DIFF
--- a/src/GraphScreen.css
+++ b/src/GraphScreen.css
@@ -1,121 +1,179 @@
 .white {
   background-color: white;
 }
+
 .GraphScreen {
-    text-align: center;
-    align-items:center;
-    flex:1;
-    height: 50%;
-    width: 50%;
-    background-color: white;
-    
+  text-align: center;
+  align-items: center;
+  flex: 1;
+  height: 50%;
+  width: 50%;
+  background-color: white;
+
+}
+
+
+.App-header {
+  background-color: #282c34;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-size: calc(10px + 2vmin);
+  color: white;
+}
+
+.App-link {
+  color: #61dafb;
+}
+
+@keyframes App-logo-spin {
+  from {
+    transform: rotate(0deg);
   }
- 
-  
-  .App-header {
-    background-color: #282c34;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    font-size: calc(10px + 2vmin);
-    color: white;
+
+  to {
+    transform: rotate(360deg);
   }
-  
-  .App-link {
-    color: #61dafb;
-  }
-  
-  @keyframes App-logo-spin {
-    from {
-      transform: rotate(0deg);
-    }
-    to {
-      transform: rotate(360deg);
-    }
-  }
-  
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
-  
-  html, body {
-    height: 100%;
-  }
-  
-  body {
-    background-color: #333;
-    color: #eee;
-    font-family: Helvetica, Arial;
-    font-size: 3vmin;
-  }
-  
-  .hidden {
-    display: none;
-  }
-  
-  /** Buttons **/
-  
-  .Top-tracks-button {
-    background-color: transparent;
-    border-radius: 2em;
-    border: 0.2em solid #1ecd97;
-    color: #1ecd97;
-    cursor: pointer;
-    font-size: 3vmin;
-    padding: 0.7em 1.5em;
-    text-transform: uppercase;
-    transition: all 0.25s ease;
-  }
-  
-  /** Background **/
-  
-  .background {
-    left: 0;
-    right: 0;
-    top: 0;
-    bottom: 0;
-    background-size: cover;
-    background-position: center center;
-    filter: blur(8em) opacity(0.6);
-    position: absolute;
-  }
-  
-  .main-wrapper {
-    align-items: center;
-    display: flex;
-    height: 100%;
-    margin: 0 auto;
-    justify-content: center;
-    position: relative;
-    width: 80%;
-    z-index: 1;
-  }
-  
-  .container {
-    align-items: center;
-    display: flex;
-    justify-content: center;
-    height: 100%;
-  }
-  
-  .main-container {
-    flex: 1;
-  }
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  background-color: #333;
+  color: #eee;
+  font-family: Helvetica, Arial;
+  font-size: 3vmin;
+}
+
+.hidden {
+  display: none;
+}
+
+/** Buttons **/
+
+.Top-tracks-button {
+  background-color: transparent;
+  border-radius: 2em;
+  border: 0.2em solid #1ecd97;
+  color: #1ecd97;
+  cursor: pointer;
+  font-size: 3vmin;
+  padding: 0.7em 1.5em;
+  text-transform: uppercase;
+  transition: all 0.25s ease;
+}
+
+/** Background **/
+
+.background {
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  background-size: cover;
+  background-position: center center;
+  filter: blur(8em) opacity(0.6);
+  position: absolute;
+}
+
+.main-wrapper {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  margin: 0 auto;
+  justify-content: center;
+  position: relative;
+  width: 80%;
+  z-index: 1;
+}
+
+.container {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  height: 100%;
+}
+
+.main-container {
+  flex: 1;
+}
+
+.pi {
+  flex: 1;
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  padding: 8em;
+  height: 100%;
+  width: 100%;
+  background-color: #000000;
+}
+
+/* standard media sizes by ryanve and Gottlieb Notschnabel from this stackoverflow: */
+/* https://stackoverflow.com/questions/6370690/media-queries-how-to-target-desktop-tablet-and-mobile */
+/* Extra media queries left in for future extensibility */
+
+/* smartphones, iPhone, portrait 480x320 phones */
+/* 320px */
+@media (min-width: 20em) {
 
   .pi {
-      flex: 1;
-      align-items:center;
-      display:flex;
-      justify-content:center;
-      padding:5em;
-      height:100%;
-      width:100%;
-      background-color: #000000;
-
+    width: 100%
   }
+}
 
- 
+/* portrait e-readers (Nook/Kindle), smaller tablets @ 600 or @ 640 wide. */
+/* 480px */
+@media (min-width:30em) {
+
+  .pi {
+    width: 100%
+  }
+}
+
+/* portrait tablets, portrait iPad, landscape e-readers, landscape 800x480 or 854x480 phones */
+/* 640px */
+@media (min-width: 40em) {
+
+  .pi {
+    width: 480px
+  }
+}
+
+/* tablet, landscape iPad, lo-res laptops ands desktops */
+/* 960px */
+@media (min-width: 60em) {
+
+  .pi {
+    width: 480px
+  }
+}
+
+/* big landscape tablets, laptops, and desktops */
+/* 1024px */
+@media (min-width: 64em) {
+
+  .pi {
+    width: 480px
+  }
+}
+
+/* hi-res laptops and desktops */
+@media (min-width: 80em) {
+
+  /* 1280px */
+  .pi {
+    width: 480px
+  }
+}


### PR DESCRIPTION
Closes #5 

Currently, the pie is very large on desktops, pushing the lower content out of the screen.

This PR adds media queries to the CSS to make the pie grow until it is 480px wide and no larger.